### PR TITLE
fix: escapes delimiter character in filters param, restores drilldown…

### DIFF
--- a/src/Common/CategorizationType.ts
+++ b/src/Common/CategorizationType.ts
@@ -29,5 +29,12 @@ export enum CategorizationType {
      * 
      * Server-side execution does *not* apply category-filters in the categorize() call.
      */
-    Normal = "Normal"
+    Normal = "Normal",
+    
+    /**     
+     * Returns categories with hits only.
+     * 
+     * @deprecated DocumentHitsOnly is deprecated. Drilldown type replaces DocumentHitsOnly categorization type.
+     */
+    DocumentHitsOnly = "DocumentHitsOnly"
 }

--- a/src/Find/FindQueryConverter.ts
+++ b/src/Find/FindQueryConverter.ts
@@ -14,7 +14,7 @@ export class FindQueryConverter extends BaseQueryConverter {
         this.addParamIfSet(params, 'df', this.createDate(query.dateFrom))
         this.addParamIfSet(params, 'dt', this.createDate(query.dateTo))
         const filters: string[] = query.filters.map(f =>
-            f.category.categoryName.join('|')
+            f.category.categoryName.join('|').replace(';','/;')
         )
         this.addParamIfSet(params, 'f', filters.join(';'))
         this.addParamIfSet(params, 'q', query.queryText)

--- a/src/Find/FindQueryConverter.ts
+++ b/src/Find/FindQueryConverter.ts
@@ -14,7 +14,7 @@ export class FindQueryConverter extends BaseQueryConverter {
         this.addParamIfSet(params, 'df', this.createDate(query.dateFrom))
         this.addParamIfSet(params, 'dt', this.createDate(query.dateTo))
         const filters: string[] = query.filters.map(f =>
-            f.category.categoryName.join('|').replace(';','/;')
+            f.category.categoryName.join('|')
         )
         this.addParamIfSet(params, 'f', filters.join(';'))
         this.addParamIfSet(params, 'q', query.queryText)


### PR DESCRIPTION
Escapes delimiter character in filters param, restores drilldown categorization type (deprecated).